### PR TITLE
Let the rails-6-support branch run with 6.0.0

### DIFF
--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.2", "< 6.0"
-  spec.add_dependency "activesupport", ">= 4.2", "< 6.0"
+  spec.add_dependency "activerecord", ">= 4.2", "< 6.1"
+  spec.add_dependency "activesupport", ">= 4.2", "< 6.1"
 
   spec.add_development_dependency "bundler", ">= 1.5", "< 3.0"
   spec.add_development_dependency "rake"

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.2", "< 6.1"
-  spec.add_dependency "activesupport", ">= 4.2", "< 6.1"
+  spec.add_dependency "activerecord", ">= 4.2", "< 7.0"
+  spec.add_dependency "activesupport", ">= 4.2", "< 7.0"
 
   spec.add_development_dependency "bundler", ">= 1.5", "< 3.0"
   spec.add_development_dependency "rake"

--- a/gemfiles/active_record_60.gemfile
+++ b/gemfiles/active_record_60.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'activerecord', '6.0.0.rc2', require: 'active_record'
-gem 'activesupport', '6.0.0.rc2', require: 'active_support'
+gem 'activerecord', '6.0.0', require: 'active_record'
+gem 'activesupport', '6.0.0', require: 'active_support'
 
 # Development dependencies
 group :development do

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -228,7 +228,7 @@ class AssociationsTest < ParanoidBaseTest
   end
 
   def test_mass_assignment_of_paranoid_column_enabled
-    if ActiveRecord::VERSION::MAJOR > 4 && ActiveRecord::VERSION::MINOR > 1
+    if Gem.loaded_specs['activerecord'].version >= Gem::Version.new('5.2.0')
       skip 'Creation as deleted is not supported with Rails >= 5.2'
     end
     now = Time.now


### PR DESCRIPTION
Relax some constraints so that we can bump to 6.0.0

Also fix one of the failing specs. 